### PR TITLE
Fix for SelectType not being respected and Fix for OrderBy/OrderByDescending failing on queries

### DIFF
--- a/src/NetCoreForce.Linq.Tests/QueryTests.cs
+++ b/src/NetCoreForce.Linq.Tests/QueryTests.cs
@@ -204,5 +204,27 @@ namespace NetCoreForce.Linq.Tests
 
             Assert.Equal("SELECT id FROM Case SKIP 10", soql);
         }
+
+        [Fact]
+        public void OrderQuery()
+        {
+            var soql =
+                Query<SfCase>(SelectTypeEnum.SelectIdAndUseAttachModel, out var provider)
+                    .OrderBy(x => x.Subject)
+                    .ToString();
+
+            Assert.Equal("SELECT id FROM Case ORDER BY subject", soql);
+        }
+
+        [Fact]
+        public void OrderDescendingQuery()
+        {
+            var soql =
+                Query<SfCase>(SelectTypeEnum.SelectIdAndUseAttachModel, out var provider)
+                    .OrderByDescending(x => x.Subject)
+                    .ToString();
+
+            Assert.Equal("SELECT id FROM Case ORDER BY subject DESC", soql);
+        }
     }
 }

--- a/src/NetCoreForce.Linq/Helper/Query.cs
+++ b/src/NetCoreForce.Linq/Helper/Query.cs
@@ -14,7 +14,7 @@ namespace NetCoreForce.Linq.Helper
     /// <summary>
     /// A default implementation of IQueryable for use with QueryProvider
     /// </summary>
-    public class Query<T> : IAsyncQueryable<T>
+    public class Query<T> : IAsyncQueryable<T>, IOrderedAsyncQueryable<T>
     {
         public Query(IAsyncQueryProvider provider)
             : this(provider, (Type)null)

--- a/src/NetCoreForce.Linq/Providers/Extensions/ForceClientSalesforceProviderExtensions.cs
+++ b/src/NetCoreForce.Linq/Providers/Extensions/ForceClientSalesforceProviderExtensions.cs
@@ -8,7 +8,7 @@ namespace NetCoreForce.Linq.Providers.Extensions
     {
         public static SalesforceQuery<T> Query<T>(this ForceClient client, SelectTypeEnum selectType = SelectTypeEnum.SelectAllAndUseAttachModel, ISalesforceNamingConvention namingConvention = null) where T : class
         {
-            return new SalesforceQuery<T>(new ForceClientSalesforceProvider<T>(client, namingConvention ?? new ModelGeneratorNamingConvention()));
+            return new SalesforceQuery<T>(new ForceClientSalesforceProvider<T>(client, namingConvention ?? new ModelGeneratorNamingConvention(), selectType));
         }
     }
 }

--- a/src/NetCoreForce.Linq/SalesforceQuery.cs
+++ b/src/NetCoreForce.Linq/SalesforceQuery.cs
@@ -6,7 +6,7 @@ using NetCoreForce.Linq.Helper;
 
 namespace NetCoreForce.Linq
 {
-    public class SalesforceQuery<T> : Query<T>, IAsyncQueryable, IAsyncQueryable<T>, IAsyncEnumerable<T>
+    public class SalesforceQuery<T> : Query<T>, IAsyncQueryable, IAsyncQueryable<T>, IAsyncEnumerable<T>, IOrderedAsyncQueryable<T>
     {
         public SalesforceQuery(IAsyncQueryProvider provider) : base(provider) { }
         public SalesforceQuery(IAsyncQueryProvider provider, Type staticType) : base(provider, staticType) { }

--- a/src/NetCoreForce.Linq/SalesforceQuery.cs
+++ b/src/NetCoreForce.Linq/SalesforceQuery.cs
@@ -6,7 +6,7 @@ using NetCoreForce.Linq.Helper;
 
 namespace NetCoreForce.Linq
 {
-    public class SalesforceQuery<T> : Query<T>, IAsyncQueryable, IAsyncQueryable<T>, IAsyncEnumerable<T>, IOrderedAsyncQueryable<T>
+    public class SalesforceQuery<T> : Query<T>, IAsyncQueryable, IAsyncQueryable<T>, IAsyncEnumerable<T>, IOrderedAsyncQueryable<T>, IOrderedAsyncQueryable
     {
         public SalesforceQuery(IAsyncQueryProvider provider) : base(provider) { }
         public SalesforceQuery(IAsyncQueryProvider provider, Type staticType) : base(provider, staticType) { }


### PR DESCRIPTION
SelectType was not being included when creating the query in ForceClientSalesforceProviderExtensions.

Calling OrderBy/OrderByDescending on a SalesforceQuery would throw the exception:
System.InvalidCastException : Unable to cast object of type 'NetCoreForce.Linq.Helper.Query`1[NetCoreForce.Models.SfCase]' to type 'System.Linq.IOrderedAsyncQueryable`1[NetCoreForce.Models.SfCase]'.

Added missing unit tests for OrderBy/OrderByDescending