### PR TITLE
Added SforceCallOptions Header Support

### DIFF
--- a/src/NetCoreForce.Client.Tests/HeaderFormatterTest.cs
+++ b/src/NetCoreForce.Client.Tests/HeaderFormatterTest.cs
@@ -57,6 +57,48 @@ namespace NetCoreForce.Client.Tests
         }
 
         [Fact]
+        public void CallOptionsHeaderWithDefaultParameters()
+        {
+            Dictionary<string, string> customHeaders = HeaderFormatter.SforceCallOptions();
+
+            Assert.Equal(1, customHeaders.Count);
+
+            var header = customHeaders.First();
+
+            string result = string.Format("{0}: {1}", header.Key, header.Value);
+
+            Assert.Equal("Sforce-Call-Options: client=ForceClient", result);
+        }
+
+        [Fact]
+        public void CallOptionsHeaderWithClientParameter()
+        {
+            Dictionary<string, string> customHeaders = HeaderFormatter.SforceCallOptions("Test");
+
+            Assert.Equal(1, customHeaders.Count);
+
+            var header = customHeaders.First();
+
+            string result = string.Format("{0}: {1}", header.Key, header.Value);
+
+            Assert.Equal("Sforce-Call-Options: client=Test", result);
+        }
+
+        [Fact]
+        public void CallOptionsHeaderWithDefaultNamespaceParameter()
+        {
+            Dictionary<string, string> customHeaders = HeaderFormatter.SforceCallOptions(defaultNamespace: "Test");
+
+            Assert.Equal(1, customHeaders.Count);
+
+            var header = customHeaders.First();
+
+            string result = string.Format("{0}: {1}", header.Key, header.Value);
+
+            Assert.Equal("Sforce-Call-Options: client=ForceClient, defaultNamespace=Test", result);
+        }
+
+        [Fact]
         public void AutoAssignHeader()
         {
             Dictionary<string, string> customHeaders = HeaderFormatter.SforceAutoAssign(false);

--- a/src/NetCoreForce.Client/ExtensionMethods.cs
+++ b/src/NetCoreForce.Client/ExtensionMethods.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace NetCoreForce.Client
 {
@@ -42,6 +43,15 @@ namespace NetCoreForce.Client
                 return new string(array);
             }
             return value;
+        }
+
+        /// <summary>
+        /// Add all key pairs from another dictionary
+        /// </summary>
+        public static void AddRange<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, Dictionary<TKey, TValue> range)
+        {
+            foreach (TKey key in range.Keys)
+            { dictionary.Add(key, range[key]); }
         }
     }
 }

--- a/src/NetCoreForce.Client/HeaderFormatter.cs
+++ b/src/NetCoreForce.Client/HeaderFormatter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text;
 
 namespace NetCoreForce.Client
 {
@@ -79,6 +80,35 @@ namespace NetCoreForce.Client
             const string headerName = "Sforce-Query-Options";
 
             string valueString = string.Format("batchSize={0}", batchSize.ToString(CultureInfo.InvariantCulture));
+
+            var customHeaders = new Dictionary<string, string>(1);
+            customHeaders.Add(headerName, valueString);
+
+            return customHeaders;
+        }
+
+        /// <summary>
+        /// Call Options Header
+        /// <para>Specifies the client-specific options when accessing REST API resources. For example, you can write client code that ignores namespace prefixes by specifying the prefix in the call options header.</para>
+        /// <remarks>The Call Options header can be used with SObject Basic Information, SObject Rows, Query, QueryAll, Search, and SObject Rows by External ID.</remarks>
+        /// </summary>
+        /// <param name="client">A string that identifies a client.</param>
+        /// <param name="defaultNamespace">A string that identifies a developer namespace prefix. Resolve field names in managed packages without having to specify the namespace everywhere.</param>
+        /// <returns>Single entry dictionary of "Sforce-Call-Options" with value of client={client}, defaultNamespace={defaultNamespace}</returns>
+        public static Dictionary<string, string> SforceCallOptions(string client = "ForceClient",
+                                                                   string defaultNamespace = null)
+        {
+            //example: "Sforce-Call-Options: client=ForceClient, defaultNamespace=Test"
+            const string headerName = "Sforce-Call-Options";
+            List<string> values = new List<string>();
+
+            if (!string.IsNullOrEmpty(client))
+            { values.Add(string.Format("client={0}", client)); }
+
+            if (!string.IsNullOrEmpty(defaultNamespace))
+            { values.Add(string.Format("defaultNamespace={0}", defaultNamespace)); }
+
+            string valueString = string.Join(", ", values);
 
             var customHeaders = new Dictionary<string, string>(1);
             customHeaders.Add(headerName, valueString);

--- a/src/NetCoreForce.Client/HeaderFormatter.cs
+++ b/src/NetCoreForce.Client/HeaderFormatter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 
 namespace NetCoreForce.Client
 {


### PR DESCRIPTION
Allows the user to include a name for identifying the client. Useful for filtering out change data capture events that a client instigated for example.

Changes:
- Added SforceCallOptions to HeaderFormatter
- Added ClientName property to ForceClient
- Added SforceCallOptions header to supported calls
- Added HeaderFormatter unit tests