### PR TITLE
[Linq] Added include/exclude for multi-picklist support

### DIFF
--- a/src/NetCoreForce.Linq.Tests/QueryTests.cs
+++ b/src/NetCoreForce.Linq.Tests/QueryTests.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using NetCoreForce.Linq.Conventions.Naming;
 using NetCoreForce.Linq.Entity;
+using NetCoreForce.Linq.Extensions;
 using NetCoreForce.Models;
 using Xunit;
 
@@ -225,6 +227,26 @@ namespace NetCoreForce.Linq.Tests
                     .ToString();
 
             Assert.Equal("SELECT id FROM Case ORDER BY subject DESC", soql);
+        }
+
+        [Fact]
+        public void IncludesQuery()
+        {
+            var soql =
+                Query<SfCase>(SelectTypeEnum.SelectIdAndUseAttachModel, out var provider)
+                    .Where(x => x.Type.Includes("test1;test2"))
+                    .ToString();
+            Assert.Equal("SELECT id FROM Case WHERE (type INCLUDES('test1;test2'))", soql);
+        }
+
+        [Fact]
+        public void ExcludesQuery()
+        {
+            var soql =
+                Query<SfCase>(SelectTypeEnum.SelectIdAndUseAttachModel, out var provider)
+                    .Where(x => x.Type.Excludes("test1;test2"))
+                    .ToString();
+            Assert.Equal("SELECT id FROM Case WHERE (type EXCLUDES('test1;test2'))", soql);
         }
     }
 }

--- a/src/NetCoreForce.Linq/Extensions/StringExtensions.cs
+++ b/src/NetCoreForce.Linq/Extensions/StringExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Linq;
+
+namespace NetCoreForce.Linq.Extensions
+{
+    public static class StringExtensions
+    {
+        public static bool Includes(this string str, string include)
+        {
+            string[] strParts = str.Split(';');
+            string[] includeParts = include.Split(';');
+            return includeParts.All(p => strParts.Contains(p));
+        }
+
+        public static bool Excludes(this string str, string exclude)
+        {
+            string[] strParts = str.Split(';');
+            string[] excludeParts = exclude.Split(';');
+            return excludeParts.All(p => !strParts.Contains(p));
+        }
+    }
+}

--- a/src/NetCoreForce.Linq/NetCoreForce.Linq.csproj
+++ b/src/NetCoreForce.Linq/NetCoreForce.Linq.csproj
@@ -40,4 +40,7 @@
   <ItemGroup>
     <ProjectReference Include="..\NetCoreForce.Client\NetCoreForce.Client.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Extensions\" />
+  </ItemGroup>
 </Project>

--- a/src/NetCoreForce.Linq/SalesforceVisitor.cs
+++ b/src/NetCoreForce.Linq/SalesforceVisitor.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Text;
 using NetCoreForce.Linq.Conventions.Naming;
 using NetCoreForce.Linq.Entity;
+using NetCoreForce.Linq.Extensions;
 
 namespace NetCoreForce.Linq
 {
@@ -244,6 +245,29 @@ namespace NetCoreForce.Linq
                             (this.Visit(m.Object) as ConstantExpression).Value.ToString(),
                             (this.Visit(m.Arguments[0]) as ConstantExpression).Value.ToString().Trim('\'').Replace("%", "\\%"));
                         
+                        return Expression.Constant(result);
+                    }
+                }
+            }
+
+            else if (m.Method.DeclaringType == typeof(StringExtensions))
+            {
+                switch (m.Method.Name)
+                {
+                    case nameof(StringExtensions.Includes):
+                    {
+                        var result = string.Format("({0} INCLUDES('{1}'))",
+                            (this.Visit(m.Arguments[0]) as ConstantExpression).Value.ToString(),
+                            (this.Visit(m.Arguments[1]) as ConstantExpression).Value.ToString().Trim('\'').Replace("%", "\\%"));
+
+                        return Expression.Constant(result);
+                    }
+                    case nameof(StringExtensions.Excludes):
+                    {
+                        var result = string.Format("({0} EXCLUDES('{1}'))",
+                            (this.Visit(m.Arguments[0]) as ConstantExpression).Value.ToString(),
+                            (this.Visit(m.Arguments[1]) as ConstantExpression).Value.ToString().Trim('\'').Replace("%", "\\%"));
+
                         return Expression.Constant(result);
                     }
                 }


### PR DESCRIPTION
Allows the user to check if a multi-picklist field contains a specific value or values.
Changes:
* Added Include/Exclude string extension
* Added Include/Exclude handling in salesforce visitor
* Added Include/Exclude unit tests