### PR TITLE
[Client/Linq] Added support for NetStandard2.1(netcoreapp3.x)

### DIFF
--- a/src/NetCoreForce.Client/ForceClient.cs
+++ b/src/NetCoreForce.Client/ForceClient.cs
@@ -217,7 +217,11 @@ namespace NetCoreForce.Client
         /// <returns><see cref="IAsyncEnumerable{T}"/> of results</returns>
         public IAsyncEnumerable<T> QueryAsync<T>(string queryString, bool queryAll = false, int? batchSize = null)
         {
+#if NETSTANDARD2_1
+            return AsyncEnumerable.Create((token) => QueryAsyncEnumerator<T>(queryString, queryAll, batchSize));
+#else
             return AsyncEnumerable.CreateEnumerable(() => QueryAsyncEnumerator<T>(queryString, queryAll, batchSize));
+#endif
         }
 
         /// <summary>
@@ -250,15 +254,19 @@ namespace NetCoreForce.Client
             var done = false;
             var nextRecordsUri = UriFormatter.Query(InstanceUrl, ApiVersion, queryString, queryAll);
 
+#if NETSTANDARD2_1
+            return AsyncEnumerator.Create(MoveNextAsync, Current, Dispose);
+            async ValueTask<bool> MoveNextAsync()
+            {
+#else
             return AsyncEnumerable.CreateEnumerator(MoveNextAsync, Current, Dispose);
-
             async Task<bool> MoveNextAsync(CancellationToken token)
             {
                 if (token.IsCancellationRequested)
                 {
                     return false;
                 }
-
+#endif
                 // If items remain in the current Batch enumerator, go to next item
                 if (currentBatchEnumerator?.MoveNext() == true)
                 {
@@ -301,11 +309,20 @@ namespace NetCoreForce.Client
                 return currentBatchEnumerator == null ? default(T) : currentBatchEnumerator.Current;
             }
 
+#if NETSTANDARD2_1
+            ValueTask Dispose()
+            {
+                currentBatchEnumerator?.Dispose();
+                jsonClient.Dispose();
+                return new ValueTask();
+            }
+#else
             void Dispose()
             {
                 currentBatchEnumerator?.Dispose();
                 jsonClient.Dispose();
             }
+#endif
         }
 
         /// <summary>
@@ -512,7 +529,7 @@ namespace NetCoreForce.Client
             return;
         }
 
-        #region metadata
+#region metadata
 
         /// <summary>
         /// Lists information about limits in your org.
@@ -620,7 +637,7 @@ namespace NetCoreForce.Client
             return await client.HttpGetAsync<DescribeGlobal>(uri);
         }
 
-        #endregion
+#endregion
 
     }
 }

--- a/src/NetCoreForce.Client/NetCoreForce.Client.csproj
+++ b/src/NetCoreForce.Client/NetCoreForce.Client.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>NetCoreForce.Client</AssemblyName>
     <Product>NetCoreForce.Client</Product>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;netstandard2.1</TargetFrameworks>
     <VersionPrefix>$(VersionPrefix)</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <!--NuGet-->
@@ -32,6 +32,9 @@
     <GeneratePackageOnBuild >true</GeneratePackageOnBuild>
     <PackageOutputPath>$(SolutionDir)/packages</PackageOutputPath>
   </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="System.Interactive.Async" Version="4.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Text.Encodings.Web" Version="4.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />

--- a/src/NetCoreForce.Linq/Entity/QueryTypeEnum.cs
+++ b/src/NetCoreForce.Linq/Entity/QueryTypeEnum.cs
@@ -2,6 +2,15 @@
 {
     public enum QueryTypeEnum
     {
+#if NETSTANDARD2_1
+        ListAsync = 0,
+        FirstAsync,
+        FirstOrDefaultAsync,
+        SingleAsync,
+        SingleOrDefaultAsync,
+        AnyAsync,
+        CountAsync,
+#else
         List = 0,
         First,
         FirstOrDefault,
@@ -9,6 +18,7 @@
         SingleOrDefault,
         Any,
         Count,
+#endif
         Enumerator
     }
 }

--- a/src/NetCoreForce.Linq/Helper/Query.cs
+++ b/src/NetCoreForce.Linq/Helper/Query.cs
@@ -10,7 +10,7 @@ using System.Threading;
 
 namespace NetCoreForce.Linq.Helper
 {
-   
+
     /// <summary>
     /// A default implementation of IQueryable for use with QueryProvider
     /// </summary>
@@ -57,7 +57,13 @@ namespace NetCoreForce.Linq.Helper
         {
             return Provider.ExecuteAsync<IAsyncEnumerator<T>>(Expression, CancellationToken.None).GetAwaiter().GetResult();
         }
-        
+
+#if NETSTANDARD2_1
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken token)
+        {
+            return Provider.ExecuteAsync<IAsyncEnumerator<T>>(Expression, token).GetAwaiter().GetResult();
+        }
+#endif
 
         public override string ToString()
         {

--- a/src/NetCoreForce.Linq/NetCoreForce.Linq.csproj
+++ b/src/NetCoreForce.Linq/NetCoreForce.Linq.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>NetCoreForce.Linq</AssemblyName>
     <Product>NetCoreForce.Linq</Product>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;netstandard2.1</TargetFrameworks>
     <VersionPrefix>$(VersionPrefix)</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <!--NuGet-->
@@ -32,10 +32,13 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageOutputPath>$(SolutionDir)/packages</PackageOutputPath>
   </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="System.Interactive.Async.Providers" Version="4.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-    <PackageReference Include="System.Interactive.Async.Providers" Version="3.2.0" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
+    <PackageReference Include="System.Interactive.Async.Providers" Version="3.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NetCoreForce.Client\NetCoreForce.Client.csproj" />

--- a/src/NetCoreForce.Linq/Providers/NullSalesforceProvider.cs
+++ b/src/NetCoreForce.Linq/Providers/NullSalesforceProvider.cs
@@ -21,8 +21,13 @@ namespace NetCoreForce.Linq.Providers
 
         protected override IAsyncEnumerator<T> ProduceAsyncEnumerator(string cmd)
         {
+#if NETSTANDARD2_1
+            return AsyncEnumerable.Empty<T>().GetAsyncEnumerator();
+#else
             return AsyncEnumerable.Empty<T>().GetEnumerator();
+#endif
         }
+
         #endregion
     }
 }

--- a/src/NetCoreForce.Linq/SalesforceProviderBase.cs
+++ b/src/NetCoreForce.Linq/SalesforceProviderBase.cs
@@ -19,7 +19,71 @@ namespace NetCoreForce.Linq
 
         public ISalesforceNamingConvention NamingConvention { get; }
         public SelectTypeEnum SelectType { get; }
-        
+
+#if NETSTANDARD2_1
+        public object Execute(Expression expression)
+        {
+            var visitor = new SalesforceVisitor(NamingConvention, SelectType);
+            var cmd = visitor.Translate(PartialEvaluator.Eval(expression));
+            switch (visitor.QueryType)
+            {
+                case QueryTypeEnum.FirstOrDefault:
+                    return ProduceAsyncEnumerable(cmd).FirstOrDefaultAsync();
+                case QueryTypeEnum.First:
+                    return ProduceAsyncEnumerable(cmd).FirstAsync();
+                case QueryTypeEnum.Single:
+                    return ProduceAsyncEnumerable(cmd).SingleAsync();
+                case QueryTypeEnum.SingleOrDefault:
+                    return ProduceAsyncEnumerable(cmd).SingleOrDefaultAsync();
+                case QueryTypeEnum.Count:
+                    return ProduceCountAsync(cmd);
+                case QueryTypeEnum.Any:
+                    return ProduceCountAsync(cmd).ContinueWith(task => task.Result > 0);
+                case QueryTypeEnum.List:
+                    return ProduceAsyncEnumerable(cmd).ToListAsync();
+                //                    var argument = typeof(TResult).GetGenericArguments()[0];
+                //
+                //                    var method = GetType().GetMethod("ProduceAsyncEnumerable", BindingFlags.Instance | BindingFlags.NonPublic).MakeGenericMethod(argument);
+                //                    var asyncEnumerable = method.Invoke(this, new object[]{cmd});
+                //
+                //
+                //                    var enumerabletype = typeof(IAsyncEnumerable<>).MakeGenericType(argument);
+                //                    var toList = GetGenericMethod(typeof(AsyncEnumerable), "ToList", typeof(IAsyncEnumerable<>)).MakeGenericMethod(argument);
+                //
+                //                    var result = (Task<TResult>) toList.Invoke(null, new [] {asyncEnumerable});
+                //
+                //                    MethodInfo GetGenericMethod(Type type, string name, params Type[] argumentTypes)
+                //                    {
+                //                        var methods = type.GetTypeInfo().GetMember("ToList").OfType<MethodInfo>().ToList();
+                //
+                //                        return methods.FirstOrDefault(m =>
+                //                        {
+                //                            var parameters = m.GetParameters();
+                //
+                //                            if (parameters.Length != argumentTypes.Length)
+                //                                return false;
+                //
+                //                            for (var i = 0; i < parameters.Length; i++)
+                //                            {
+                //                                var parameterType = parameters[i].ParameterType;
+                //
+                //                                if (parameterType.IsGenericType)
+                //                                    parameterType = parameterType.GetGenericTypeDefinition();
+                //
+                //                                if (parameterType != argumentTypes[i])
+                //                                    return false;
+                //                            }
+                //
+                //                            return true;
+                //                        });
+                //                    }
+
+                case QueryTypeEnum.Enumerator:
+                default:
+                    return Task.FromResult(ProduceAsyncEnumerator(cmd));
+            }
+        }
+#else
         public object Execute(Expression expression)
         {
             var visitor = new SalesforceVisitor(NamingConvention, SelectType);
@@ -82,12 +146,18 @@ namespace NetCoreForce.Linq
                     return Task.FromResult(ProduceAsyncEnumerator(cmd));
             }
         }
-        
+#endif
+
 
         protected abstract Task<int> ProduceCountAsync(string cmd);
 
+#if NETSTANDARD2_1
+        protected IAsyncEnumerable<T> ProduceAsyncEnumerable(string cmd)
+            => AsyncEnumerable.Create((token) => ProduceAsyncEnumerator(cmd));
+#else
         protected IAsyncEnumerable<T> ProduceAsyncEnumerable(string cmd)
             => AsyncEnumerable.CreateEnumerable(() => ProduceAsyncEnumerator(cmd));
+#endif
 
 
         protected abstract IAsyncEnumerator<T> ProduceAsyncEnumerator(string cmd);
@@ -98,19 +168,27 @@ namespace NetCoreForce.Linq
             return visitor.Translate(PartialEvaluator.Eval(expression));
         }
 
-        #region Implementation of IAsyncQueryProvider
+#region Implementation of IAsyncQueryProvider
 
         IAsyncQueryable<TElement> IAsyncQueryProvider.CreateQuery<TElement>(Expression expression)
         {
             return new Query<TElement>(this, expression);
         }
 
+#if NETSTANDARD2_1
+        public ValueTask<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken token)
+        {
+            var result = Execute(expression);
+            return (ValueTask<TResult>)result;
+        }
+#else
         public Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken token) 
         {
             var result = Execute(expression);
             return (Task<TResult>) result;
         }
-        
-        #endregion
+#endif
+
+#endregion
     }
 }

--- a/src/NetCoreForce.Linq/SalesforceProviderBase.cs
+++ b/src/NetCoreForce.Linq/SalesforceProviderBase.cs
@@ -27,19 +27,19 @@ namespace NetCoreForce.Linq
             var cmd = visitor.Translate(PartialEvaluator.Eval(expression));
             switch (visitor.QueryType)
             {
-                case QueryTypeEnum.FirstOrDefault:
+                case QueryTypeEnum.FirstOrDefaultAsync:
                     return ProduceAsyncEnumerable(cmd).FirstOrDefaultAsync();
-                case QueryTypeEnum.First:
+                case QueryTypeEnum.FirstAsync:
                     return ProduceAsyncEnumerable(cmd).FirstAsync();
-                case QueryTypeEnum.Single:
+                case QueryTypeEnum.SingleAsync:
                     return ProduceAsyncEnumerable(cmd).SingleAsync();
-                case QueryTypeEnum.SingleOrDefault:
+                case QueryTypeEnum.SingleOrDefaultAsync:
                     return ProduceAsyncEnumerable(cmd).SingleOrDefaultAsync();
-                case QueryTypeEnum.Count:
-                    return ProduceCountAsync(cmd);
-                case QueryTypeEnum.Any:
-                    return ProduceCountAsync(cmd).ContinueWith(task => task.Result > 0);
-                case QueryTypeEnum.List:
+                case QueryTypeEnum.CountAsync:
+                    return new ValueTask<int>(ProduceCountAsync(cmd));
+                case QueryTypeEnum.AnyAsync:
+                    return new ValueTask<bool>(ProduceCountAsync(cmd).ContinueWith(task => task.Result > 0));
+                case QueryTypeEnum.ListAsync:
                     return ProduceAsyncEnumerable(cmd).ToListAsync();
                 //                    var argument = typeof(TResult).GetGenericArguments()[0];
                 //
@@ -148,7 +148,6 @@ namespace NetCoreForce.Linq
         }
 #endif
 
-
         protected abstract Task<int> ProduceCountAsync(string cmd);
 
 #if NETSTANDARD2_1
@@ -185,7 +184,7 @@ namespace NetCoreForce.Linq
         public Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken token) 
         {
             var result = Execute(expression);
-            return (Task<TResult>) result;
+            return (Task<TResult>)result;
         }
 #endif
 

--- a/src/NetCoreForce.Linq/SalesforceVisitor.cs
+++ b/src/NetCoreForce.Linq/SalesforceVisitor.cs
@@ -140,12 +140,18 @@ namespace NetCoreForce.Linq
                         Skip = (int) ((m.Arguments[1] as ConstantExpression).Value);
                         this.Visit(m.Arguments[0]);
                         break;
-
+#if NETSTANDARD2_1
+                    case nameof(AsyncQueryable.FirstAsync):
+                    case nameof(AsyncQueryable.FirstOrDefaultAsync):
+                    case nameof(AsyncQueryable.SingleAsync):
+                    case nameof(AsyncQueryable.SingleOrDefaultAsync):
+#else
                     case nameof(AsyncQueryable.First):
                     case nameof(AsyncQueryable.FirstOrDefault):
                     case nameof(AsyncQueryable.Single):
                     case nameof(AsyncQueryable.SingleOrDefault):
-                        
+#endif
+
                         QueryType = (QueryTypeEnum) Enum.Parse(typeof(QueryTypeEnum), methodName);
                         Take = 2;
                         if (m.Arguments.Count > 1)
@@ -155,7 +161,17 @@ namespace NetCoreForce.Linq
 
                         this.Visit(m.Arguments[0]);
                         break;
-                        
+#if NETSTANDARD2_1
+                    case nameof(AsyncQueryable.ToListAsync):
+                        QueryType = QueryTypeEnum.List;
+
+                        this.Visit(m.Arguments[0]);
+
+                        break;
+
+                    case nameof(AsyncQueryable.AnyAsync):
+                    case nameof(AsyncQueryable.CountAsync):
+#else
                     case nameof(AsyncQueryable.ToList):
                         QueryType = QueryTypeEnum.List;
 
@@ -165,6 +181,7 @@ namespace NetCoreForce.Linq
 
                     case nameof(AsyncQueryable.Any):
                     case nameof(AsyncQueryable.Count):
+#endif
                         QueryType = (QueryTypeEnum) Enum.Parse(typeof(QueryTypeEnum), methodName);
                         if (m.Arguments.Count > 1)
                         {


### PR DESCRIPTION
Fixes this kind of build error when using with netcoreapp3.x:
`Error CS0433 The type 'IAsyncEnumerable<T>' exists in both 'System.Interactive.Async, Version=3.2.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263' and 'System.Runtime, Version=4.2.1.0`