### PR TITLE
feat: add .NET 6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
         with:
           dotnet-version: 3.1.x
 
-      # - name: Setup .NET Core 5.0
-      #   uses: actions/setup-dotnet@v1
-      #   with:
-      #     dotnet-version: 5.0.x
+      - name: Setup .NET Core 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 2022-01-13 v3.1.0
+
+* feat: add .NET 6 support
+* build: add net6.0 build and test targets
+* build: on MacOS only target .net6.0 (Workaround for issues developing muti-arch on M1 processor machines)
+* chore: remove unnecessary exception catching and re-throws
+
 ### 2021-05-07 v3.0.1
 
 * Fix: incorrect URI when calling organization limits, make URI formatting more consistent

--- a/build.props
+++ b/build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+  
     <!--Versioning-->
     <VersionPrefix>3.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
@@ -7,16 +8,6 @@
     <!-- Targets -->
     <LangVersion>8.0</LangVersion>
     <LibTargetFrameworks>netstandard2.0;netstandard2.1</LibTargetFrameworks>
-
-    <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('OSX'))">
-      <AppTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</AppTargetFrameworks>
-      <TestTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</TestTargetFrameworks>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-      <AppTargetFrameworks>net6.0</AppTargetFrameworks>
-      <TestTargetFrameworks>net6.0</TestTargetFrameworks>
-    </PropertyGroup>
 
     <!--NuGet-->
     <Authors>Anthony Reilly</Authors>
@@ -31,6 +22,17 @@
 
     <!--Project Root-->
     <SolutionDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), *.sln))</SolutionDir>
+  </PropertyGroup>
+
+  <!-- Targets -->
+  <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('OSX'))">
+    <AppTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</AppTargetFrameworks>
+    <TestTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</TestTargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+    <AppTargetFrameworks>net6.0</AppTargetFrameworks>
+    <TestTargetFrameworks>net6.0</TestTargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/build.props
+++ b/build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-  
+
     <!--Versioning-->
-    <VersionPrefix>3.0.1</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
 
     <!-- Targets -->

--- a/build.props
+++ b/build.props
@@ -7,8 +7,16 @@
     <!-- Targets -->
     <LangVersion>8.0</LangVersion>
     <LibTargetFrameworks>netstandard2.0;netstandard2.1</LibTargetFrameworks>
-    <AppTargetFrameworks>netcoreapp2.1;netcoreapp3.1</AppTargetFrameworks>
-    <TestTargetFrameworks>netcoreapp2.1;netcoreapp3.1</TestTargetFrameworks>
+
+    <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('OSX'))">
+      <AppTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</AppTargetFrameworks>
+      <TestTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</TestTargetFrameworks>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+      <AppTargetFrameworks>net6.0</AppTargetFrameworks>
+      <TestTargetFrameworks>net6.0</TestTargetFrameworks>
+    </PropertyGroup>
 
     <!--NuGet-->
     <Authors>Anthony Reilly</Authors>
@@ -24,4 +32,5 @@
     <!--Project Root-->
     <SolutionDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), *.sln))</SolutionDir>
   </PropertyGroup>
+
 </Project>

--- a/src/NetCoreForce.Client.Tests/MockReponse.cs
+++ b/src/NetCoreForce.Client.Tests/MockReponse.cs
@@ -32,7 +32,7 @@ namespace NetCoreForce.Client.Tests
             catch (Exception ex)
             {
                 Console.WriteLine(string.Format("Error reading file [{0}]: {1}", filename, ex.Message));
-                throw ex;
+                throw;
             }
         }
 

--- a/src/NetCoreForce.Client/AuthenticationClient.cs
+++ b/src/NetCoreForce.Client/AuthenticationClient.cs
@@ -89,7 +89,7 @@ namespace NetCoreForce.Client
                 }
 
                 //otherwise throw the original AggregateException as-is
-                throw ex;
+                throw;
             }
 
         }

--- a/src/NetCoreForce.Client/ForceClient.cs
+++ b/src/NetCoreForce.Client/ForceClient.cs
@@ -52,10 +52,6 @@ namespace NetCoreForce.Client
             {
                 throw ax.InnerException;
             }
-            catch (Exception ex)
-            {
-                throw ex;
-            }
         }
 
         /// <summary>
@@ -179,7 +175,7 @@ namespace NetCoreForce.Client
             catch (Exception ex)
             {
                 Debug.WriteLine("Error querying: " + ex.Message);
-                throw ex;
+                throw;
             }
         }
 
@@ -311,7 +307,7 @@ namespace NetCoreForce.Client
             catch (Exception ex)
             {
                 Debug.WriteLine("Error searching: " + ex.Message);
-                throw ex;
+                throw;
             }
         }
 
@@ -336,7 +332,7 @@ namespace NetCoreForce.Client
             catch (Exception ex)
             {
                 Debug.WriteLine("Error searching: " + ex.Message);
-                throw ex;
+                throw;
             }
         }
 

--- a/src/NetCoreForce.Client/JsonClient.cs
+++ b/src/NetCoreForce.Client/JsonClient.cs
@@ -66,37 +66,22 @@ namespace NetCoreForce.Client
         public async Task<T> HttpGetAsync<T>(Uri uri, Dictionary<string, string> customHeaders = null, bool deserializeResponse = true)
         {
             //TODO: can this handle T = string?
-            try
-            {
-                return await HttpAsync<T>(uri, HttpMethod.Get, null, customHeaders, deserializeResponse);
-            }
-            catch (Exception ex)
-            {
-                throw ex;
-            }
+            return await HttpAsync<T>(uri, HttpMethod.Get, null, customHeaders, deserializeResponse);
         }
 
         public async Task<T> HttpPostAsync<T>(object inputObject, Uri uri, Dictionary<string, string> customHeaders = null, bool deserializeResponse = true)
         {
             var json = JsonSerializer.SerializeForCreate(inputObject);
 
-            try
-            {
-                var content = new StringContent(json, Encoding.UTF8, JsonMimeType);
+            var content = new StringContent(json, Encoding.UTF8, JsonMimeType);
 
-                HttpRequestMessage request = new HttpRequestMessage();
-                request.Headers.Authorization = _authHeaderValue;
-                request.RequestUri = uri;
-                request.Method = HttpMethod.Post;
-                request.Content = content;
+            HttpRequestMessage request = new HttpRequestMessage();
+            request.Headers.Authorization = _authHeaderValue;
+            request.RequestUri = uri;
+            request.Method = HttpMethod.Post;
+            request.Content = content;
 
-                return await GetResponse<T>(request, customHeaders, deserializeResponse);
-
-            }
-            catch (Exception ex)
-            {
-                throw ex;
-            }
+            return await GetResponse<T>(request, customHeaders, deserializeResponse);
         }
 
         /// <summary>
@@ -112,68 +97,47 @@ namespace NetCoreForce.Client
         /// <returns></returns>
         public async Task<T> HttpPatchAsync<T>(object inputObject, Uri uri, Dictionary<string, string> customHeaders = null, bool deserializeResponse = true, bool serializeComplete = false, bool includeSObjectId = false)
         {
-            try
+            string json;
+            if (serializeComplete)
             {
-                string json;
-                if (serializeComplete)
-                {
-                    json = JsonSerializer.SerializeComplete(inputObject, false);
-                }
-                else if (includeSObjectId)
-                {
-                    json = JsonSerializer.SerializeForUpdateWithObjectId(inputObject);
-                }
-                else
-                {
-                    json = JsonSerializer.SerializeForUpdate(inputObject);
-                }
-
-                var content = new StringContent(json, Encoding.UTF8, JsonMimeType);
-
-                return await HttpAsync<T>(uri, new HttpMethod("PATCH"), content, customHeaders, deserializeResponse);
+                json = JsonSerializer.SerializeComplete(inputObject, false);
             }
-            catch (Exception ex)
+            else if (includeSObjectId)
             {
-                throw ex;
+                json = JsonSerializer.SerializeForUpdateWithObjectId(inputObject);
             }
+            else
+            {
+                json = JsonSerializer.SerializeForUpdate(inputObject);
+            }
+
+            var content = new StringContent(json, Encoding.UTF8, JsonMimeType);
+
+            return await HttpAsync<T>(uri, new HttpMethod("PATCH"), content, customHeaders, deserializeResponse);
         }
 
         public async Task<T> HttpDeleteAsync<T>(Uri uri, Dictionary<string, string> customHeaders = null, bool deserializeResponse = true)
         {
-            try
-            {
-                HttpRequestMessage request = new HttpRequestMessage();
-                request.Headers.Authorization = _authHeaderValue;
-                request.RequestUri = uri;
-                request.Method = HttpMethod.Delete;
+            HttpRequestMessage request = new HttpRequestMessage();
+            request.Headers.Authorization = _authHeaderValue;
+            request.RequestUri = uri;
+            request.Method = HttpMethod.Delete;
 
-                return await GetResponse<T>(request, customHeaders, deserializeResponse);
-            }
-            catch (Exception ex)
-            {
-                throw ex;
-            }
+            return await GetResponse<T>(request, customHeaders, deserializeResponse);
         }
 
         private async Task<T> HttpAsync<T>(Uri uri, HttpMethod httpMethod, HttpContent content = null, Dictionary<string, string> customHeaders = null, bool deserializeResponse = true)
         {
-            try
+            HttpRequestMessage request = new HttpRequestMessage();
+            request.Headers.Authorization = _authHeaderValue;
+            request.RequestUri = uri;
+            request.Method = httpMethod;
+            if (content != null)
             {
-                HttpRequestMessage request = new HttpRequestMessage();
-                request.Headers.Authorization = _authHeaderValue;
-                request.RequestUri = uri;
-                request.Method = httpMethod;
-                if (content != null)
-                {
-                    request.Content = content;
-                }
+                request.Content = content;
+            }
 
-                return await GetResponse<T>(request, customHeaders, deserializeResponse);
-            }
-            catch (Exception ex)
-            {
-                throw ex;
-            }
+            return await GetResponse<T>(request, customHeaders, deserializeResponse);
         }
 
         /// <summary>
@@ -298,9 +262,9 @@ namespace NetCoreForce.Client
                         throw new ForceApiException(msg, errors, responseMessage.StatusCode);
                     }
                 }
-                catch (ForceApiException ex)
+                catch (ForceApiException)
                 {
-                    throw ex;
+                    throw;
                 }
                 catch (Exception ex)
                 {

--- a/src/NetCoreForce.FunctionalTests/CRUDTests.cs
+++ b/src/NetCoreForce.FunctionalTests/CRUDTests.cs
@@ -90,15 +90,8 @@ namespace NetCoreForce.FunctionalTests
             firstAccount.Description = firstUpdatedDescription;
             secondAccount.Description = secondUpdatedDescription;
 
-            try
-            {
-                List<UpdateMultipleResponse> responses = await client.UpdateRecords(new List<SObject>() { firstAccount, secondAccount }, true);
-                Assert.True(responses.All(r => r.Success), "Failed to update multiple objects");
-            }
-            catch (Exception ex)
-            {
-                throw ex;
-            }
+            List<UpdateMultipleResponse> responses = await client.UpdateRecords(new List<SObject>() { firstAccount, secondAccount }, true);
+            Assert.True(responses.All(r => r.Success), "Failed to update multiple objects");
 
             //get newly updated objects
             string secondNewAccountId = secondCreateResp.Id;

--- a/src/NetCoreForce.FunctionalTests/ForceClientFixture.cs
+++ b/src/NetCoreForce.FunctionalTests/ForceClientFixture.cs
@@ -35,7 +35,7 @@ namespace NetCoreForce.FunctionalTests
             catch (Exception ex)
             {
                 Console.WriteLine("Error reading credentials file: " + ex.Message);
-                throw ex;
+                throw;
             }
         }
 

--- a/src/NetCoreForce.ModelGenerator/Program.cs
+++ b/src/NetCoreForce.ModelGenerator/Program.cs
@@ -346,7 +346,7 @@ namespace NetCoreForce.ModelGenerator
             catch (ForceAuthException ex)
             {
                 Console.WriteLine("Error authenticating: " + ex.Message);
-                throw ex;
+                throw;
             }
 
             ForceClient client = new ForceClient(auth.AccessInfo.InstanceUrl, auth.ApiVersion, auth.AccessInfo.AccessToken);
@@ -588,7 +588,7 @@ namespace NetCoreForce.ModelGenerator
                 catch (Exception ex)
                 {
                     Console.WriteLine("Exception generating models: " + ex.Message);
-                    throw ex;
+                    throw;
                 }
             }
 

--- a/src/SampleConsole/Program.cs
+++ b/src/SampleConsole/Program.cs
@@ -124,7 +124,7 @@ namespace SampleConsole
             catch (Exception ex)
             {
                 Console.WriteLine("Error reading credentials file: " + ex.Message);
-                throw ex;
+                throw;
             }
         }
     }


### PR DESCRIPTION
### 2022-01-13 v3.1.0

* feat: add .NET 6 support
* build: add net6.0 build and test targets
* build: on MacOS only target .net6.0 (Workaround for issues developing muti-arch on M1 processor machines)
* chore: remove unnecessary exception catching and re-throws