### PR TITLE
allows multipusert by external Id

### DIFF
--- a/src/NetCoreForce.Client/ForceClient.cs
+++ b/src/NetCoreForce.Client/ForceClient.cs
@@ -464,6 +464,56 @@ namespace NetCoreForce.Client
         }
 
         /// <summary>
+        /// Insert multiple reocrds.
+        /// The list can contain up to 200 objects.
+        /// Each object must contain an attributes map. The map must contain a value for type.
+        /// Each object must contain an id field with a valid ID value.
+        /// </summary>
+        /// <param name="sObjects">Objects to update</param>
+        /// <param name="sObjectTypeName"></param>
+        /// <param name="allOrNone">Optional. Indicates whether to roll back the entire request when the update of any object fails (true) or to continue with the independent update of other objects in the request. The default is false.</param>
+        /// <param name="customHeaders">Custom headers to include in request (Optional). await The HeaderFormatter helper class can be used to generate the custom header as needed.</param>
+        /// <returns>List of InsertMultipleResponse objects, includes response for each object (id, success, errors)</returns>
+        /// <exception cref="ArgumentException">Thrown when missing required information</exception>
+        /// <exception cref="ForceApiException">Thrown when update fails</exception>
+        public async Task<InsertMultipleResponse> InsertRecords(List<SObject> sObjects, string sObjectTypeName, bool allOrNone = false, Dictionary<string, string> customHeaders = null)
+        {
+            if (sObjects == null)
+            {
+                throw new ArgumentNullException("sObjects");
+            }
+
+            foreach (SObject sObject in sObjects)
+            {
+                if (sObject.Attributes == null || string.IsNullOrEmpty(sObject.Attributes.Type))
+                {
+                    throw new ForceApiException("Objects are missing Type property in Attributes map");
+                }
+            }
+
+            Dictionary<string, string> headers = new Dictionary<string, string>();
+
+            //Add call options
+            Dictionary<string, string> callOptions = HeaderFormatter.SforceCallOptions(ClientName);
+            headers.AddRange(callOptions);
+
+            //Add custom headers if specified
+            if (customHeaders != null)
+            {
+                headers.AddRange(customHeaders);
+            }
+
+            var uri = UriFormatter.SObjectsComposite(InstanceUrl, ApiVersion, sObjectTypeName);
+
+            JsonClient client = new JsonClient(AccessToken, _httpClient);
+
+            InsertMultipleRequest insertMultipleRequest = new InsertMultipleRequest(sObjects);
+
+            return await client.HttpPostAsync<InsertMultipleResponse>(insertMultipleRequest, uri, headers);
+
+        }
+
+        /// <summary>
         /// Update multiple records based on external field id
         /// The list can contain up to 200 objects.
         /// The list can contain objects of different types, including custom objects.

--- a/src/NetCoreForce.Client/ForceClient.cs
+++ b/src/NetCoreForce.Client/ForceClient.cs
@@ -465,6 +465,43 @@ namespace NetCoreForce.Client
         }
 
         /// <summary>
+        /// Delete multiple reocrds.
+        /// The list can contain up to 200 ids.
+        /// </summary>
+        /// <param name="allOrNone">Optional. Indicates whether to roll back the entire request when the update of any object fails (true) or to continue with the independent update of other objects in the request. The default is false.</param>
+        /// <param name="customHeaders">Custom headers to include in request (Optional). await The HeaderFormatter helper class can be used to generate the custom header as needed.</param>
+        /// <returns>List of UpdateMultipleResponse objects, includes response for each object (id, success, errors)</returns>
+        /// <exception cref="ArgumentException">Thrown when missing required information</exception>
+        /// <exception cref="ForceApiException">Thrown when update fails</exception>
+        public async Task<List<UpdateMultipleResponse>> DeleteRecords(IEnumerable<string> ids, bool allOrNone = false, Dictionary<string, string> customHeaders = null)
+        {
+            if (ids == null)
+            {
+                throw new ArgumentNullException("ids");
+            }
+
+
+            Dictionary<string, string> headers = new Dictionary<string, string>();
+
+            //Add call options
+            Dictionary<string, string> callOptions = HeaderFormatter.SforceCallOptions(ClientName);
+            headers.AddRange(callOptions);
+
+            //Add custom headers if specified
+            if (customHeaders != null)
+            {
+                headers.AddRange(customHeaders);
+            }
+
+            var uri = UriFormatter.SObjectsCompositeDelete(InstanceUrl, ApiVersion, ids);
+
+            JsonClient client = new JsonClient(AccessToken, _httpClient);
+
+            return await client.HttpDeleteAsync<List<UpdateMultipleResponse>>(uri, headers);
+
+        }
+
+        /// <summary>
         /// Insert multiple reocrds.
         /// The list can contain up to 200 objects.
         /// Each object must contain an attributes map. The map must contain a value for type.

--- a/src/NetCoreForce.Client/ForceClient.cs
+++ b/src/NetCoreForce.Client/ForceClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -721,6 +722,20 @@ namespace NetCoreForce.Client
             JsonClient client = new JsonClient(AccessToken, _httpClient);
 
             return await client.HttpGetAsync<DescribeGlobal>(uri);
+        }
+
+        /// <summary>
+        /// Returns a stream with the given content version
+        /// </summary>
+        /// <param name="versionId"></param>
+        /// <returns></returns>
+        public async Task<Stream> GetContentVersionAsync(string versionId)
+        {
+            var uri = UriFormatter.ContentVersion(InstanceUrl, ApiVersion, versionId);
+
+            JsonClient client = new JsonClient(AccessToken, _httpClient);
+
+            return await client.HttpGetStreamAsync(uri);
         }
 
         #endregion

--- a/src/NetCoreForce.Client/Models/UpdateMultipleRequest.cs
+++ b/src/NetCoreForce.Client/Models/UpdateMultipleRequest.cs
@@ -32,4 +32,24 @@ namespace NetCoreForce.Client.Models
         [JsonProperty(PropertyName = "allOrNone")]
         public bool AllOrNone { get; set; }
     }
+
+    public class InsertMultipleRequest
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="records"></param>
+        public InsertMultipleRequest(List<SObject> records)
+        {
+            Records = records;
+        }
+
+        /// <summary>
+        /// Required. A list of sObjects. In a POST request using sObject Collections,
+        /// set the type attribute for each object, but don’t set the id field for any object.
+        /// </summary>
+        [JsonProperty(PropertyName = "records")]
+        public List<SObject> Records { get; set; }
+
+    }
 }

--- a/src/NetCoreForce.Client/Models/UpdateMultipleResponse.cs
+++ b/src/NetCoreForce.Client/Models/UpdateMultipleResponse.cs
@@ -37,4 +37,28 @@ namespace NetCoreForce.Client.Models
         [JsonProperty(PropertyName = "fields")]
         public List<string> Fields { get; set; }
     }
+
+    public class InsertMultipleResponse
+    {
+        /// <summary>
+        /// results
+        /// </summary>
+        [JsonProperty(PropertyName = "hasErrors")]
+        public bool HasErrors { get; set; }
+        /// <summary>
+        /// results
+        /// </summary>
+        [JsonProperty(PropertyName = "results")]
+        public List<InsertMultipleResult> Results { get; set; }
+    }
+
+    public class InsertMultipleResult
+    {
+        [JsonProperty(PropertyName = "referenceId")]
+        public string ReferenceId { get; set; }
+
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+    }
+
 }

--- a/src/NetCoreForce.Client/UriFormatter.cs
+++ b/src/NetCoreForce.Client/UriFormatter.cs
@@ -106,6 +106,22 @@ namespace NetCoreForce.Client
         }
 
         /// <summary>
+        /// VersionData for  given version Id
+        /// Can be used to retrieve the stream associated to a contentversion
+        /// </summary>
+        public static Uri ContentVersion(string instanceUrl, string apiVersion, string versionId)
+        {
+            if (string.IsNullOrEmpty(instanceUrl)) throw new ArgumentNullException("instanceUrl");
+            if (string.IsNullOrEmpty(apiVersion)) throw new ArgumentNullException("apiVersion");
+            if (string.IsNullOrEmpty(versionId)) throw new ArgumentNullException("versionId");
+
+
+            Uri uri = new Uri(BaseUri(instanceUrl), $"{apiVersion}/sobjects/ContentVersion/{versionId}/VersionData");
+
+            return uri;
+        }
+
+        /// <summary>
         /// SObject Describe
         /// Completely describes the individual metadata at all levels for the specified object.
         /// </summary>

--- a/src/NetCoreForce.Client/UriFormatter.cs
+++ b/src/NetCoreForce.Client/UriFormatter.cs
@@ -163,6 +163,26 @@ namespace NetCoreForce.Client
 
         /// <summary>
         /// SObject Composite
+        /// Used for: Insert multiple
+        /// </summary>
+        /// <param name="instanceUrl">SFDC instance URL, e.g. "https://na99.salesforce.com"</param>
+        /// <param name="apiVersion">SFDC API version, e.g. "v41.0"</param>
+        /// <param name="sObjectName"></param>
+        /// <returns></returns>
+        public static Uri SObjectsComposite(string instanceUrl, string apiVersion, string sObjectName)
+        {
+            if (string.IsNullOrEmpty(instanceUrl)) throw new ArgumentNullException("instanceUrl");
+            if (string.IsNullOrEmpty(apiVersion)) throw new ArgumentNullException("apiVersion");
+
+            //format: /vXX.X/composite/sobjects
+
+            Uri uri = new Uri(BaseUri(instanceUrl), $"{apiVersion}/composite/tree/{sObjectName}");
+
+            return uri;
+        }
+
+        /// <summary>
+        /// SObject Composite
         /// Used for: Update multiple
         /// </summary>
         /// <param name="instanceUrl">SFDC instance URL, e.g. "https://na99.salesforce.com"</param>

--- a/src/NetCoreForce.Client/UriFormatter.cs
+++ b/src/NetCoreForce.Client/UriFormatter.cs
@@ -181,6 +181,30 @@ namespace NetCoreForce.Client
         }
 
         /// <summary>
+        /// SObject Composite
+        /// Used for: Update multiple by external field
+        /// </summary>
+        /// <param name="instanceUrl">SFDC instance URL, e.g. "https://na99.salesforce.com"</param>
+        /// <param name="apiVersion">SFDC API version, e.g. "v41.0"</param>
+        /// <param name="sObjectName"></param>
+        /// <param name="fieldName"></param>
+        /// <returns></returns>
+        public static Uri SObjectsComposite(string instanceUrl, string apiVersion, string sObjectName, string fieldName)
+        {
+            if (string.IsNullOrEmpty(instanceUrl)) throw new ArgumentNullException("instanceUrl");
+            if (string.IsNullOrEmpty(apiVersion)) throw new ArgumentNullException("apiVersion");
+            if (string.IsNullOrEmpty(sObjectName)) throw new ArgumentNullException("sObjectName");
+            if (string.IsNullOrEmpty(fieldName)) throw new ArgumentNullException("fieldName");
+
+            //format: /vXX.X/composite/sobjects/SObjectName/fieldName
+
+            Uri uri = new Uri(BaseUri(instanceUrl), $"{apiVersion}/composite/sobjects/{sObjectName}/{fieldName}");
+
+            return uri;
+        }
+
+
+        /// <summary>
         /// SObject Rows by External ID
         /// Creates new records or updates existing records (upserts records) based on the value of a specified external ID field.
         /// </summary>
@@ -217,7 +241,7 @@ namespace NetCoreForce.Client
             Uri uri = new Uri(BaseUri(instanceUrl), $"{apiVersion}/sobjects/{sObjectName}/{objectId}/{blobField}");
 
             return uri;
-        }        
+        }
 
         /// <summary>
         /// SOQL Query
@@ -303,7 +327,7 @@ namespace NetCoreForce.Client
             if (!string.IsNullOrEmpty(state))
             {
                 prms.Add("state", state);
-            }            
+            }
 
             string url = QueryHelpers.AddQueryString(loginUrl, prms);
 
@@ -355,7 +379,7 @@ namespace NetCoreForce.Client
             if (!string.IsNullOrEmpty(state))
             {
                 prms.Add("state", state);
-            }            
+            }
 
             string url = QueryHelpers.AddQueryString(loginUrl, prms);
 
@@ -373,21 +397,21 @@ namespace NetCoreForce.Client
         public static Uri RefreshTokenUrl(
             string tokenRefreshUrl,
             string refreshToken,
-            string clientId,            
+            string clientId,
             string clientSecret = "")
         {
             if (tokenRefreshUrl == null) throw new ArgumentNullException("tokenRefreshUrl");
             if (refreshToken == null) throw new ArgumentNullException("refreshToken");
-            if (clientId == null) throw new ArgumentNullException("clientId");            
+            if (clientId == null) throw new ArgumentNullException("clientId");
 
             Dictionary<string, string> prms = new Dictionary<string, string>();
             prms.Add("grant_type", "refresh_token");
             prms.Add("refresh_token", refreshToken);
             prms.Add("client_id", clientId);
-            if(!string.IsNullOrEmpty(clientSecret))
+            if (!string.IsNullOrEmpty(clientSecret))
             {
                 prms.Add("client_secret", clientSecret);
-            }            
+            }
             prms.Add("format", "json");
 
             string url = QueryHelpers.AddQueryString(tokenRefreshUrl, prms);

--- a/src/NetCoreForce.Client/UriFormatter.cs
+++ b/src/NetCoreForce.Client/UriFormatter.cs
@@ -218,6 +218,28 @@ namespace NetCoreForce.Client
 
         /// <summary>
         /// SObject Composite
+        /// Used for: Delete multiple
+        /// </summary>
+        /// <param name="instanceUrl">SFDC instance URL, e.g. "https://na99.salesforce.com"</param>
+        /// <param name="apiVersion">SFDC API version, e.g. "v41.0"</param>
+        /// <param name="ids"></param>
+        /// <returns></returns>
+        public static Uri SObjectsCompositeDelete(string instanceUrl, string apiVersion, IEnumerable<string> ids)
+        {
+            if (string.IsNullOrEmpty(instanceUrl)) throw new ArgumentNullException("instanceUrl");
+            if (string.IsNullOrEmpty(apiVersion)) throw new ArgumentNullException("apiVersion");
+
+            //format: /vXX.X/composite/sobjects
+
+            Uri uri = new Uri(BaseUri(instanceUrl), $"{apiVersion}/composite/sobjects");
+
+            string uriwithIds = QueryHelpers.AddQueryString(uri.ToString(), "ids", string.Join(",", ids));
+
+            return new Uri(uriwithIds);
+        }
+
+        /// <summary>
+        /// SObject Composite
         /// Used for: Update multiple by external field
         /// </summary>
         /// <param name="instanceUrl">SFDC instance URL, e.g. "https://na99.salesforce.com"</param>


### PR DESCRIPTION
This allows to use the `composite/sobjects/SObjectName/fieldName` route to make multiple upserts based on an external index 