### PR TITLE
Add Header option to SObjectDescribeFull to allow for If-Modified-Since

### DIFF
--- a/src/NetCoreForce.Client/ForceClient.cs
+++ b/src/NetCoreForce.Client/ForceClient.cs
@@ -597,14 +597,15 @@ namespace NetCoreForce.Client
         /// <para>Use the SObject Describe resource to retrieve all the metadata for an object, including information about each field, URLs, and child relationships.</para>
         /// </summary>
         /// <param name="objectTypeName">SObject name, e.g. Account</param>
+        /// <param name="customHeaders">Example If-Modified-Since: Wed, 3 Jul 2013 19:43:31 GMT</param>
         /// <returns>Returns SObjectMetadataAll with full object meta including field metadata</returns>
-        public async Task<SObjectDescribeFull> GetObjectDescribe(string objectTypeName)
+        public async Task<SObjectDescribeFull> GetObjectDescribe(string objectTypeName, Dictionary<string, string> customHeaders = null)
         {
             var uri = UriFormatter.SObjectDescribe(InstanceUrl, ApiVersion, objectTypeName);
 
             JsonClient client = new JsonClient(AccessToken, _httpClient);
 
-            return await client.HttpGetAsync<SObjectDescribeFull>(uri);
+            return await client.HttpGetAsync<SObjectDescribeFull>(uri, customHeaders);
         }
 
         /// <summary>


### PR DESCRIPTION
According to https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/sobject_describe_with_ifmodified_header.htm you can choose to retrieve object metadata only if it has changed after a certain date (specified by header).  
This is incredibly useful for those with data rate limits and need to implement caching.
I think this change would also work if you limited to just the one header type "If-Modified-Since" (and took in a date) but wouldn't be as flexible.  