### PR TITLE
Update ValidFor to byte[]

### DIFF
--- a/src/NetCoreForce.Client/Models/PicklistValue.cs
+++ b/src/NetCoreForce.Client/Models/PicklistValue.cs
@@ -25,9 +25,11 @@ namespace NetCoreForce.Client.Models
         [JsonProperty(PropertyName = "label")]
         public string Label { get; set; }
 
-        // TODO: validate type of validFor field
-        // [JsonProperty(PropertyName = "validFor")]
-        // public string ValidFor { get; set; }
+        /// <summary>
+        /// Valid for property
+        /// </summary>
+        [JsonProperty(PropertyName = "validFor")]
+        public byte[] ValidFor { get; set; }
 
         /// <summary>
         /// Picklist item value


### PR DESCRIPTION
ValidFor is a byte array.  

- https://developer.salesforce.com/docs/atlas.en-us.238.0.api.meta/api/sforce_api_calls_describesobjects_describesobjectresult.htm

![image](https://user-images.githubusercontent.com/104081882/179439728-dcd19ad9-8940-4dc9-8bd7-97cb817e7677.png)

This will allow further enhancements to calculate picklists for dependent items.