### PR TITLE
adding calculatedFormula field on SObjectFieldMetadata

### DIFF
--- a/src/NetCoreForce.Client/Models/SObjectFieldMetadata.cs
+++ b/src/NetCoreForce.Client/Models/SObjectFieldMetadata.cs
@@ -12,6 +12,9 @@ namespace NetCoreForce.Client.Models
         [JsonProperty(PropertyName = "calculated")]
         public bool Calculated { get; set; }
 
+        [JsonProperty(PropertyName = "calculatedFormula")]
+        public string calculatedFormula { get; set; }
+
         [JsonProperty(PropertyName = "createable")]
         public bool Creatable { get; set; }
 


### PR DESCRIPTION
adding calculated formula. According to this article this field is a string:

https://developer.salesforce.com/docs/atlas.en-us.pages.meta/pages/pages_variables_global_objecttype_schema_fields_reference.htm