### PR TITLE
Add ConfigureAwait(false) to await calls

### DIFF
--- a/src/NetCoreForce.Client/ForceClient.cs
+++ b/src/NetCoreForce.Client/ForceClient.cs
@@ -86,7 +86,7 @@ namespace NetCoreForce.Client
         private async Task Login(string clientId, string clientSecret, string username, string password, string tokenRequestEndpoint, string apiVersion = null, HttpClient httpClient = null)
         {
             AuthenticationClient authClient = new AuthenticationClient(apiVersion);
-            await authClient.UsernamePasswordAsync(clientId, clientSecret, username, password, tokenRequestEndpoint);
+            await authClient.UsernamePasswordAsync(clientId, clientSecret, username, password, tokenRequestEndpoint).ConfigureAwait(false);
 
             Initialize(authClient.AccessInfo.InstanceUrl, authClient.ApiVersion, authClient.AccessInfo.AccessToken, httpClient, authClient.AccessInfo);
         }
@@ -161,7 +161,7 @@ namespace NetCoreForce.Client
                         queryUri = new Uri(new Uri(InstanceUrl), nextRecordsUrl);
                     }
 
-                    QueryResult<T> qr = await client.HttpGetAsync<QueryResult<T>>(queryUri, headers);
+                    QueryResult<T> qr = await client.HttpGetAsync<QueryResult<T>>(queryUri, headers).ConfigureAwait(false);
 
 #if DEBUG
                     Debug.WriteLine(string.Format("Got query resuts, {0} totalSize, {1} in this batch, final batch: {2}",
@@ -207,7 +207,7 @@ namespace NetCoreForce.Client
         /// <returns>result object</returns>
         public async Task<T> QuerySingle<T>(string queryString, bool queryAll = false)
         {
-            List<T> results = await Query<T>(queryString, queryAll);
+            List<T> results = await Query<T>(queryString, queryAll).ConfigureAwait(false);
 
             if (results != null && results.Count > 1)
             {
@@ -253,7 +253,7 @@ namespace NetCoreForce.Client
 
             while (hasMoreRecords)
             {
-                var qr = await jsonClient.HttpGetAsync<QueryResult<T>>(nextRecordsUri, headers);
+                var qr = await jsonClient.HttpGetAsync<QueryResult<T>>(nextRecordsUri, headers).ConfigureAwait(false);
 
 #if DEBUG
                 Debug.WriteLine($"Got query resuts, {qr.TotalSize} totalSize, {qr.Records.Count} in this batch, final batch: {qr.Done}");
@@ -299,7 +299,7 @@ namespace NetCoreForce.Client
 
             var jsonClient = new JsonClient(AccessToken, SharedHttpClient);
             var uri = UriFormatter.Query(InstanceUrl, ApiVersion, queryString);
-            var qr = await jsonClient.HttpGetAsync<QueryResult<object>>(uri, headers);
+            var qr = await jsonClient.HttpGetAsync<QueryResult<object>>(uri, headers).ConfigureAwait(false);
 
             return qr.TotalSize;
         }
@@ -319,7 +319,7 @@ namespace NetCoreForce.Client
 
                 JsonClient client = new JsonClient(AccessToken, SharedHttpClient);
 
-                SearchResult<T> searchResult = await client.HttpGetAsync<SearchResult<T>>(uri, headers);
+                SearchResult<T> searchResult = await client.HttpGetAsync<SearchResult<T>>(uri, headers).ConfigureAwait(false);
 
                 return searchResult;
             }
@@ -344,7 +344,7 @@ namespace NetCoreForce.Client
 
                 JsonClient client = new JsonClient(AccessToken, SharedHttpClient);
 
-                SearchResult<SObjectGeneric> searchResult = await client.HttpGetAsync<SearchResult<SObjectGeneric>>(uri, headers);
+                SearchResult<SObjectGeneric> searchResult = await client.HttpGetAsync<SearchResult<SObjectGeneric>>(uri, headers).ConfigureAwait(false);
 
                 return searchResult;
             }
@@ -368,7 +368,7 @@ namespace NetCoreForce.Client
 
             JsonClient client = new JsonClient(AccessToken, SharedHttpClient);
 
-            return await client.HttpGetAsync<T>(uri, headers);
+            return await client.HttpGetAsync<T>(uri, headers).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -404,7 +404,7 @@ namespace NetCoreForce.Client
 
             JsonClient client = new JsonClient(AccessToken, SharedHttpClient);
 
-            return await client.HttpPostAsync<CreateResponse>(sObject, uri, headers, fieldsToNull: fieldsToNull, ignoreNulls: ignoreNulls);
+            return await client.HttpPostAsync<CreateResponse>(sObject, uri, headers, fieldsToNull: fieldsToNull, ignoreNulls: ignoreNulls).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -476,7 +476,7 @@ namespace NetCoreForce.Client
 
             SObjectTreeRequest treeRequest = new SObjectTreeRequest(sObjects);
 
-            return await client.HttpPostAsync<SObjectTreeResponse>(treeRequest, uri, headers, fieldsToNull: fieldsToNull, ignoreNulls: ignoreNulls);
+            return await client.HttpPostAsync<SObjectTreeResponse>(treeRequest, uri, headers, fieldsToNull: fieldsToNull, ignoreNulls: ignoreNulls).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -515,7 +515,7 @@ namespace NetCoreForce.Client
 
             JsonClient client = new JsonClient(AccessToken, SharedHttpClient);
 
-            await client.HttpPatchAsync<object>(sObject, uri, headers, ignoreNulls: ignoreNulls, fieldsToNull: fieldsToNull);
+            await client.HttpPatchAsync<object>(sObject, uri, headers, ignoreNulls: ignoreNulls, fieldsToNull: fieldsToNull).ConfigureAwait(false);
 
             return;
         }
@@ -573,7 +573,7 @@ namespace NetCoreForce.Client
 
             UpsertRequest upsertRequest = new UpsertRequest(sObjects, allOrNone);
 
-            return await client.HttpPatchAsync<List<UpsertResponse>>(upsertRequest, uri, headers, includeSObjectId: true, fieldsToNull: fieldsToNull, ignoreNulls: ignoreNulls);
+            return await client.HttpPatchAsync<List<UpsertResponse>>(upsertRequest, uri, headers, includeSObjectId: true, fieldsToNull: fieldsToNull, ignoreNulls: ignoreNulls).ConfigureAwait(false);
 
         }
 
@@ -614,7 +614,7 @@ namespace NetCoreForce.Client
 
             JsonClient client = new JsonClient(AccessToken, SharedHttpClient);
 
-            return await client.HttpPatchAsync<UpsertResponse>(sObject, uri, headers, fieldsToNull: fieldsToNull, ignoreNulls: ignoreNulls);
+            return await client.HttpPatchAsync<UpsertResponse>(sObject, uri, headers, fieldsToNull: fieldsToNull, ignoreNulls: ignoreNulls).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -631,7 +631,7 @@ namespace NetCoreForce.Client
 
             JsonClient client = new JsonClient(AccessToken, SharedHttpClient);
 
-            await client.HttpDeleteAsync<object>(uri, headers);
+            await client.HttpDeleteAsync<object>(uri, headers).ConfigureAwait(false);
 
             return;
         }
@@ -656,13 +656,13 @@ namespace NetCoreForce.Client
             string objectId = match.Groups[2].Value;
             string blobField = match.Groups[3].Value;
 
-            return await BlobRetrieveStream(sObjectTypeName, objectId, blobField);
+            return await BlobRetrieveStream(sObjectTypeName, objectId, blobField).ConfigureAwait(false);
         }
 
         public async Task<Stream> BlobRetrieveStream(string sObjectTypeName, string objectId, string blobField)
         {
-            HttpResponseMessage response = await BlobRetrieveResponse(sObjectTypeName, objectId, blobField);
-            return await response.Content.ReadAsStreamAsync();
+            HttpResponseMessage response = await BlobRetrieveResponse(sObjectTypeName, objectId, blobField).ConfigureAwait(false);
+            return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         }
 
         // public async Task<byte[]> BlobRetrieveBytes(string blobUrl)
@@ -734,7 +734,7 @@ namespace NetCoreForce.Client
 
             JsonClient client = new JsonClient(AccessToken, SharedHttpClient);
 
-            return await client.HttpGetAsync<OrganizationLimits>(uri);
+            return await client.HttpGetAsync<OrganizationLimits>(uri).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -745,7 +745,7 @@ namespace NetCoreForce.Client
         /// <returns>List of SalesforceVersion objects</returns>
         public async Task<List<SalesforceVersion>> GetAvailableRestApiVersions(string currentInstanceUrl = null)
         {
-            return await GetAvailableRestApiVersions(currentInstanceUrl, true);
+            return await GetAvailableRestApiVersions(currentInstanceUrl, true).ConfigureAwait(false);
         }
 
         private async Task<List<SalesforceVersion>> GetAvailableRestApiVersions(string currentInstanceUrl = null, bool deserializeResponse = true)
@@ -769,7 +769,7 @@ namespace NetCoreForce.Client
 
             JsonClient client = new JsonClient(AccessToken, SharedHttpClient);
 
-            return await client.HttpGetAsync<List<SalesforceVersion>>(uri: uri, deserializeResponse: deserializeResponse);
+            return await client.HttpGetAsync<List<SalesforceVersion>>(uri: uri, deserializeResponse: deserializeResponse).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -782,7 +782,7 @@ namespace NetCoreForce.Client
         {
             JsonClient client = new JsonClient(AccessToken, SharedHttpClient);
 
-            return await client.HttpGetAsync<UserInfo>(new Uri(identityUrl));
+            return await client.HttpGetAsync<UserInfo>(new Uri(identityUrl)).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -798,7 +798,7 @@ namespace NetCoreForce.Client
 
             JsonClient client = new JsonClient(AccessToken, SharedHttpClient);
 
-            return await client.HttpGetAsync<SObjectBasicInfo>(uri, headers);
+            return await client.HttpGetAsync<SObjectBasicInfo>(uri, headers).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -813,7 +813,7 @@ namespace NetCoreForce.Client
 
             JsonClient client = new JsonClient(AccessToken, SharedHttpClient);
 
-            return await client.HttpGetAsync<SObjectDescribeFull>(uri);
+            return await client.HttpGetAsync<SObjectDescribeFull>(uri).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -827,7 +827,7 @@ namespace NetCoreForce.Client
 
             JsonClient client = new JsonClient(AccessToken, SharedHttpClient);
 
-            return await client.HttpGetAsync<DescribeGlobal>(uri);
+            return await client.HttpGetAsync<DescribeGlobal>(uri).ConfigureAwait(false);
         }
 
         #endregion

--- a/src/NetCoreForce.Client/JsonClient.cs
+++ b/src/NetCoreForce.Client/JsonClient.cs
@@ -74,7 +74,7 @@ namespace NetCoreForce.Client
         public async Task<T> HttpGetAsync<T>(Uri uri, Dictionary<string, string> customHeaders = null, bool deserializeResponse = true)
         {
             //TODO: can this handle T = string?
-            return await HttpAsync<T>(uri, HttpMethod.Get, null, customHeaders, deserializeResponse);
+            return await HttpAsync<T>(uri, HttpMethod.Get, null, customHeaders, deserializeResponse).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace NetCoreForce.Client
             request.Method = HttpMethod.Post;
             request.Content = content;
 
-            return await GetResponse<T>(request, customHeaders, deserializeResponse);
+            return await GetResponse<T>(request, customHeaders, deserializeResponse).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace NetCoreForce.Client
 
             var content = new StringContent(json, Encoding.UTF8, JsonMimeType);
 
-            return await HttpAsync<T>(uri, new HttpMethod("PATCH"), content, customHeaders, deserializeResponse);
+            return await HttpAsync<T>(uri, new HttpMethod("PATCH"), content, customHeaders, deserializeResponse).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -166,7 +166,7 @@ namespace NetCoreForce.Client
             request.RequestUri = uri;
             request.Method = HttpMethod.Delete;
 
-            return await GetResponse<T>(request, customHeaders, deserializeResponse);
+            return await GetResponse<T>(request, customHeaders, deserializeResponse).ConfigureAwait(false);
         }
 
         private async Task<T> HttpAsync<T>(Uri uri, HttpMethod httpMethod, HttpContent content = null, Dictionary<string, string> customHeaders = null, bool deserializeResponse = true)
@@ -180,7 +180,7 @@ namespace NetCoreForce.Client
                 request.Content = content;
             }
 
-            return await GetResponse<T>(request, customHeaders, deserializeResponse);
+            return await GetResponse<T>(request, customHeaders, deserializeResponse).ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
Allows this library to be used in places where async await is not supported. Adding ConfigureAwait(false) prevents synchronization context from hanging when using Wait or Result